### PR TITLE
1. Kafka 를 어플리케이션과 연동하고, Producer 와 Consumer 테스트를 작성한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0")
     implementation("org.springdoc:springdoc-openapi-starter-common:2.1.0")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation 'org.springframework.kafka:spring-kafka'
 
     implementation("com.slack.api:slack-api-client:1.38.1")
     implementation("com.slack.api:slack-api-model:1.38.1")
@@ -52,6 +53,7 @@ dependencies {
     testImplementation("com.slack.api:slack-api-client:1.38.1")
     testImplementation("com.slack.api:slack-api-model-kotlin-extension:1.38.1")
     testImplementation("com.slack.api:slack-api-client-kotlin-extension:1.38.1")
+    testImplementation("org.springframework.kafka:spring-kafka-test")
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/kotlin/com/hhplus/concert/business/application/dto/PaymentEventOutBoxServiceDto.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/application/dto/PaymentEventOutBoxServiceDto.kt
@@ -1,0 +1,11 @@
+package com.hhplus.concert.business.application.dto
+
+import com.hhplus.concert.common.type.EventStatus
+
+class PaymentEventOutBoxServiceDto {
+    data class EventOutBox(
+        val id: Long,
+        val paymentId: Long,
+        val eventStatus: EventStatus,
+    )
+}

--- a/src/main/kotlin/com/hhplus/concert/business/application/service/PaymentEventOutBoxService.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/application/service/PaymentEventOutBoxService.kt
@@ -25,6 +25,9 @@ class PaymentEventOutBoxService(
             eventStatus = eventStatus,
         )
 
+    /**
+     * outbox 의 상태를 변경한다.
+     */
     fun updateEventStatus(
         paymentId: Long,
         eventStatus: EventStatus,
@@ -40,5 +43,22 @@ class PaymentEventOutBoxService(
      */
     fun publishPaymentEvent(event: PaymentEvent) {
         paymentEventPublisher.publishPaymentEvent(event)
+    }
+
+    /**
+     * 실패로 간주하는 이벤트를 재시도한다.
+     * 실패 간주 조건 : 5분이 지났음에도 여전히 상태가 INIT 인 Event
+     */
+    fun retryFailedPaymentEvent() {
+        paymentEventOutBoxManager.retryFailedPaymentEvent().forEach {
+            paymentEventPublisher.publishPaymentEvent(PaymentEvent(it.paymentId))
+        }
+    }
+
+    /**
+     * 발행된 후 일주일이 지난 EventOutBox 를 삭제한다.
+     */
+    fun deletePublishedPaymentEvent() {
+        paymentEventOutBoxManager.deletePublishedPaymentEvent()
     }
 }

--- a/src/main/kotlin/com/hhplus/concert/business/application/service/PaymentEventOutBoxService.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/application/service/PaymentEventOutBoxService.kt
@@ -1,0 +1,57 @@
+package com.hhplus.concert.business.application.service
+
+import com.hhplus.concert.business.application.dto.PaymentEventOutBoxServiceDto
+import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
+import com.hhplus.concert.business.domain.manager.payment.event.PaymentEvent
+import com.hhplus.concert.business.domain.manager.payment.event.PaymentEventOutBoxManager
+import com.hhplus.concert.business.domain.manager.payment.event.PaymentEventPublisher
+import com.hhplus.concert.common.type.EventStatus
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Service
+
+@Service
+class PaymentEventOutBoxService(
+    private val paymentEventOutBoxManager: PaymentEventOutBoxManager,
+    @Qualifier("kafka") private val paymentEventPublisher: PaymentEventPublisher,
+) {
+    /**
+     * outbox 를 저장한다.
+     */
+    fun saveEventOutBox(
+        domainId: Long,
+        eventStatus: EventStatus,
+    ): PaymentEventOutBox =
+        paymentEventOutBoxManager.saveEventOutBox(
+            domainId = domainId,
+            eventStatus = eventStatus,
+        )
+
+    /**
+     * paymentId 로 eventOutBox 를 찾아온다.
+     */
+    fun findEventByPaymentId(paymentId: Long): PaymentEventOutBoxServiceDto.EventOutBox {
+        val eventOutBox = paymentEventOutBoxManager.findEventByPaymentId(paymentId)
+        return PaymentEventOutBoxServiceDto.EventOutBox(
+            id = eventOutBox.id,
+            paymentId = eventOutBox.paymentId,
+            eventStatus = eventOutBox.eventStatus,
+        )
+    }
+
+    fun updateEventStatus(
+        paymentId: Long,
+        eventStatus: EventStatus,
+    ) {
+        paymentEventOutBoxManager.updateEventStatus(
+            paymentId = paymentId,
+            eventStatus = eventStatus,
+        )
+    }
+
+    /**
+     * kafka 이벤트를 발행한다.
+     */
+    fun publishPaymentEvent(event: PaymentEvent) {
+        paymentEventPublisher.publishPaymentEvent(event)
+    }
+}

--- a/src/main/kotlin/com/hhplus/concert/business/application/service/PaymentEventOutBoxService.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/application/service/PaymentEventOutBoxService.kt
@@ -1,6 +1,5 @@
 package com.hhplus.concert.business.application.service
 
-import com.hhplus.concert.business.application.dto.PaymentEventOutBoxServiceDto
 import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
 import com.hhplus.concert.business.domain.manager.payment.event.PaymentEvent
 import com.hhplus.concert.business.domain.manager.payment.event.PaymentEventOutBoxManager
@@ -25,18 +24,6 @@ class PaymentEventOutBoxService(
             domainId = domainId,
             eventStatus = eventStatus,
         )
-
-    /**
-     * paymentId 로 eventOutBox 를 찾아온다.
-     */
-    fun findEventByPaymentId(paymentId: Long): PaymentEventOutBoxServiceDto.EventOutBox {
-        val eventOutBox = paymentEventOutBoxManager.findEventByPaymentId(paymentId)
-        return PaymentEventOutBoxServiceDto.EventOutBox(
-            id = eventOutBox.id,
-            paymentId = eventOutBox.paymentId,
-            eventStatus = eventOutBox.eventStatus,
-        )
-    }
 
     fun updateEventStatus(
         paymentId: Long,

--- a/src/main/kotlin/com/hhplus/concert/business/domain/entity/PaymentEventOutBox.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/entity/PaymentEventOutBox.kt
@@ -17,6 +17,7 @@ import java.time.LocalDateTime
 class PaymentEventOutBox(
     paymentId: Long,
     eventStatus: EventStatus,
+    publishedAt: LocalDateTime = LocalDateTime.now(),
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,7 +33,8 @@ class PaymentEventOutBox(
         protected set
 
     @Column(name = "published_at", nullable = false)
-    var publishedAt: LocalDateTime = LocalDateTime.now()
+    var publishedAt: LocalDateTime = publishedAt
+        protected set
 
     fun updateEventStatus(eventStatus: EventStatus) {
         this.eventStatus = eventStatus

--- a/src/main/kotlin/com/hhplus/concert/business/domain/entity/PaymentEventOutBox.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/entity/PaymentEventOutBox.kt
@@ -31,8 +31,8 @@ class PaymentEventOutBox(
     var eventStatus: EventStatus = eventStatus
         protected set
 
-    @Column(name = "published_date_time", nullable = false)
-    var publishedDateTime: LocalDateTime = LocalDateTime.now()
+    @Column(name = "published_at", nullable = false)
+    var publishedAt: LocalDateTime = LocalDateTime.now()
 
     fun updateEventStatus(eventStatus: EventStatus) {
         this.eventStatus = eventStatus

--- a/src/main/kotlin/com/hhplus/concert/business/domain/entity/PaymentEventOutBox.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/entity/PaymentEventOutBox.kt
@@ -1,0 +1,40 @@
+package com.hhplus.concert.business.domain.entity
+
+import com.hhplus.concert.common.type.EventStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import java.time.LocalDateTime
+
+/**
+ * EventOutBox Entity
+ */
+@Entity
+class PaymentEventOutBox(
+    paymentId: Long,
+    eventStatus: EventStatus,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0
+
+    @Column(name = "payment_id", nullable = false)
+    var paymentId: Long = paymentId
+        protected set
+
+    @Column(name = "event_status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    var eventStatus: EventStatus = eventStatus
+        protected set
+
+    @Column(name = "published_date_time", nullable = false)
+    var publishedDateTime: LocalDateTime = LocalDateTime.now()
+
+    fun updateEventStatus(eventStatus: EventStatus) {
+        this.eventStatus = eventStatus
+    }
+}

--- a/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/PaymentEvent.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/PaymentEvent.kt
@@ -1,5 +1,0 @@
-package com.hhplus.concert.business.domain.manager.payment
-
-data class PaymentEvent(
-    val paymentId: Long,
-)

--- a/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/PaymentManager.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/PaymentManager.kt
@@ -9,6 +9,7 @@ import com.hhplus.concert.business.domain.manager.payment.event.PaymentEventPubl
 import com.hhplus.concert.business.domain.repository.PaymentHistoryRepository
 import com.hhplus.concert.business.domain.repository.PaymentRepository
 import com.hhplus.concert.common.type.PaymentStatus
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
@@ -16,7 +17,7 @@ import java.time.LocalDateTime
 class PaymentManager(
     private val paymentRepository: PaymentRepository,
     private val paymentHistoryRepository: PaymentHistoryRepository,
-    private val paymentEventPublisher: PaymentEventPublisher,
+    @Qualifier("application") private val paymentEventPublisher: PaymentEventPublisher,
 ) {
     /**
      * 결제를 실행한다.

--- a/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/PaymentManager.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/PaymentManager.kt
@@ -4,6 +4,8 @@ import com.hhplus.concert.business.domain.entity.Payment
 import com.hhplus.concert.business.domain.entity.PaymentHistory
 import com.hhplus.concert.business.domain.entity.Reservation
 import com.hhplus.concert.business.domain.entity.User
+import com.hhplus.concert.business.domain.manager.payment.event.PaymentEvent
+import com.hhplus.concert.business.domain.manager.payment.event.PaymentEventPublisher
 import com.hhplus.concert.business.domain.repository.PaymentHistoryRepository
 import com.hhplus.concert.business.domain.repository.PaymentRepository
 import com.hhplus.concert.common.type.PaymentStatus

--- a/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/PaymentMessageSender.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/PaymentMessageSender.kt
@@ -3,8 +3,6 @@ package com.hhplus.concert.business.domain.manager.payment
 import com.hhplus.concert.business.domain.message.MessageAlarmPayload
 import com.hhplus.concert.business.domain.message.MessageClient
 import com.hhplus.concert.business.domain.repository.PaymentRepository
-import com.hhplus.concert.common.error.code.ErrorCode
-import com.hhplus.concert.common.error.exception.BusinessException
 import com.hhplus.concert.common.type.AlarmLevel
 import com.hhplus.concert.common.type.PaymentStatus
 import org.springframework.stereotype.Component
@@ -21,7 +19,7 @@ class PaymentMessageSender(
      * 외부 API 를 통해 Payment Event 메세지를 전송한다.
      */
     fun sendPaymentEventMessage(paymentId: Long) {
-        val payment = paymentRepository.findById(paymentId) ?: throw BusinessException.NotFound(ErrorCode.Payment.NOT_FOUND)
+        val payment = paymentRepository.findById(paymentId) ?: return
 
         messageClient.sendMessage(
             MessageAlarmPayload(

--- a/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/event/PaymentEvent.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/event/PaymentEvent.kt
@@ -1,0 +1,5 @@
+package com.hhplus.concert.business.domain.manager.payment.event
+
+data class PaymentEvent(
+    val paymentId: Long,
+)

--- a/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/event/PaymentEventOutBoxManager.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/event/PaymentEventOutBoxManager.kt
@@ -27,14 +27,14 @@ class PaymentEventOutBoxManager(
             ),
         )
 
-    fun findEventByPaymentId(paymentId: Long): PaymentEventOutBox = paymentEventOutBoxRepository.findByPaymentId(paymentId)
+    fun findEventByPaymentId(paymentId: Long): PaymentEventOutBox =
+        paymentEventOutBoxRepository.findByPaymentId(paymentId) ?: throw BusinessException.NotFound(ErrorCode.Event.BAD_REQUEST)
 
     fun updateEventStatus(
         paymentId: Long,
         eventStatus: EventStatus,
     ) {
-        val eventOutbox = paymentEventOutBoxRepository.findByPaymentId(paymentId)
-        eventOutbox.updateEventStatus(eventStatus)
+        paymentEventOutBoxRepository.findByPaymentId(paymentId)?.updateEventStatus(eventStatus)
     }
 
     fun retryFailedPaymentEvent(): List<PaymentEventOutBox> =

--- a/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/event/PaymentEventOutBoxManager.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/event/PaymentEventOutBoxManager.kt
@@ -2,13 +2,20 @@ package com.hhplus.concert.business.domain.manager.payment.event
 
 import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
 import com.hhplus.concert.business.domain.repository.PaymentEventOutBoxRepository
+import com.hhplus.concert.common.error.code.ErrorCode
+import com.hhplus.concert.common.error.exception.BusinessException
 import com.hhplus.concert.common.type.EventStatus
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Component
 class PaymentEventOutBoxManager(
     private val paymentEventOutBoxRepository: PaymentEventOutBoxRepository,
 ) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
     fun saveEventOutBox(
         domainId: Long,
         eventStatus: EventStatus,
@@ -28,5 +35,17 @@ class PaymentEventOutBoxManager(
     ) {
         val eventOutbox = paymentEventOutBoxRepository.findByPaymentId(paymentId)
         eventOutbox.updateEventStatus(eventStatus)
+    }
+
+    fun retryFailedPaymentEvent(): List<PaymentEventOutBox> =
+        paymentEventOutBoxRepository.findAllFailedEvent(LocalDateTime.now().minusMinutes(5))
+
+    @Transactional
+    fun deletePublishedPaymentEvent() {
+        runCatching {
+            paymentEventOutBoxRepository.deleteAllPublishedEvent(LocalDateTime.now().minusDays(7))
+        }.onFailure {
+            throw BusinessException.BadRequest(ErrorCode.Event.BAD_REQUEST)
+        }
     }
 }

--- a/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/event/PaymentEventOutBoxManager.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/event/PaymentEventOutBoxManager.kt
@@ -1,0 +1,32 @@
+package com.hhplus.concert.business.domain.manager.payment.event
+
+import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
+import com.hhplus.concert.business.domain.repository.PaymentEventOutBoxRepository
+import com.hhplus.concert.common.type.EventStatus
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentEventOutBoxManager(
+    private val paymentEventOutBoxRepository: PaymentEventOutBoxRepository,
+) {
+    fun saveEventOutBox(
+        domainId: Long,
+        eventStatus: EventStatus,
+    ): PaymentEventOutBox =
+        paymentEventOutBoxRepository.save(
+            PaymentEventOutBox(
+                paymentId = domainId,
+                eventStatus = eventStatus,
+            ),
+        )
+
+    fun findEventByPaymentId(paymentId: Long): PaymentEventOutBox = paymentEventOutBoxRepository.findByPaymentId(paymentId)
+
+    fun updateEventStatus(
+        paymentId: Long,
+        eventStatus: EventStatus,
+    ) {
+        val eventOutbox = paymentEventOutBoxRepository.findByPaymentId(paymentId)
+        eventOutbox.updateEventStatus(eventStatus)
+    }
+}

--- a/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/event/PaymentEventPublisher.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/manager/payment/event/PaymentEventPublisher.kt
@@ -1,4 +1,4 @@
-package com.hhplus.concert.business.domain.manager.payment
+package com.hhplus.concert.business.domain.manager.payment.event
 
 interface PaymentEventPublisher {
     fun publishPaymentEvent(event: PaymentEvent)

--- a/src/main/kotlin/com/hhplus/concert/business/domain/repository/PaymentEventOutBoxRepository.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/repository/PaymentEventOutBoxRepository.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 interface PaymentEventOutBoxRepository {
     fun save(paymentEventOutBox: PaymentEventOutBox): PaymentEventOutBox
 
-    fun findByPaymentId(paymentId: Long): PaymentEventOutBox
+    fun findByPaymentId(paymentId: Long): PaymentEventOutBox?
 
     fun findAllFailedEvent(dateTime: LocalDateTime): List<PaymentEventOutBox>
 

--- a/src/main/kotlin/com/hhplus/concert/business/domain/repository/PaymentEventOutBoxRepository.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/repository/PaymentEventOutBoxRepository.kt
@@ -1,0 +1,9 @@
+package com.hhplus.concert.business.domain.repository
+
+import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
+
+interface PaymentEventOutBoxRepository {
+    fun save(paymentEventOutBox: PaymentEventOutBox): PaymentEventOutBox
+
+    fun findByPaymentId(paymentId: Long): PaymentEventOutBox
+}

--- a/src/main/kotlin/com/hhplus/concert/business/domain/repository/PaymentEventOutBoxRepository.kt
+++ b/src/main/kotlin/com/hhplus/concert/business/domain/repository/PaymentEventOutBoxRepository.kt
@@ -1,9 +1,14 @@
 package com.hhplus.concert.business.domain.repository
 
 import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
+import java.time.LocalDateTime
 
 interface PaymentEventOutBoxRepository {
     fun save(paymentEventOutBox: PaymentEventOutBox): PaymentEventOutBox
 
     fun findByPaymentId(paymentId: Long): PaymentEventOutBox
+
+    fun findAllFailedEvent(dateTime: LocalDateTime): List<PaymentEventOutBox>
+
+    fun deleteAllPublishedEvent(dateTime: LocalDateTime)
 }

--- a/src/main/kotlin/com/hhplus/concert/common/config/KafkaConfig.kt
+++ b/src/main/kotlin/com/hhplus/concert/common/config/KafkaConfig.kt
@@ -1,0 +1,49 @@
+package com.hhplus.concert.common.config
+
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+
+@Configuration
+class KafkaConfig(
+    @Value("\${spring.kafka.bootstrap-servers}") private val bootstrapServers: String,
+) {
+    private fun producerProps() =
+        mapOf(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to bootstrapServers,
+            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+        )
+
+    private fun consumerProps() =
+        mapOf(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to bootstrapServers,
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
+        )
+
+    @Bean
+    fun producerFactory(): ProducerFactory<String, String> = DefaultKafkaProducerFactory(producerProps())
+
+    @Bean
+    fun consumerFactory(): ConsumerFactory<String, String> = DefaultKafkaConsumerFactory(consumerProps())
+
+    @Bean
+    fun kafkaListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, String> =
+        ConcurrentKafkaListenerContainerFactory<String, String>().apply {
+            consumerFactory = consumerFactory()
+        }
+
+    @Bean
+    fun kafkaTemplate(): KafkaTemplate<String, String> = KafkaTemplate(producerFactory())
+}

--- a/src/main/kotlin/com/hhplus/concert/common/error/code/ErrorCode.kt
+++ b/src/main/kotlin/com/hhplus/concert/common/error/code/ErrorCode.kt
@@ -68,5 +68,6 @@ sealed interface ErrorCode {
         override val message: String,
     ) : ErrorCode {
         BAD_REQUEST(HttpStatus.BAD_REQUEST, "EVENT001", "잘못된 이벤트 요청입니다."),
+        NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT002", "해당 이벤트를 찾을 수 없습니다."),
     }
 }

--- a/src/main/kotlin/com/hhplus/concert/common/error/code/ErrorCode.kt
+++ b/src/main/kotlin/com/hhplus/concert/common/error/code/ErrorCode.kt
@@ -61,4 +61,12 @@ sealed interface ErrorCode {
         NOT_FOUND(HttpStatus.NOT_FOUND, "QUEUE001", "해당 대기열을 찾을 수 없습니다."),
         NOT_ALLOWED(HttpStatus.BAD_REQUEST, "QUEUE002", "해당 대기열은 허용되지 않습니다."),
     }
+
+    enum class Event(
+        override val httpStatus: HttpStatus,
+        override val errorCode: String,
+        override val message: String,
+    ) : ErrorCode {
+        BAD_REQUEST(HttpStatus.BAD_REQUEST, "EVENT001", "잘못된 이벤트 요청입니다."),
+    }
 }

--- a/src/main/kotlin/com/hhplus/concert/common/type/EventStatus.kt
+++ b/src/main/kotlin/com/hhplus/concert/common/type/EventStatus.kt
@@ -1,0 +1,6 @@
+package com.hhplus.concert.common.type
+
+enum class EventStatus {
+    INIT,
+    PUBLISHED,
+}

--- a/src/main/kotlin/com/hhplus/concert/infrastructure/impl/PaymentEventOutBoxRepositoryImpl.kt
+++ b/src/main/kotlin/com/hhplus/concert/infrastructure/impl/PaymentEventOutBoxRepositoryImpl.kt
@@ -12,7 +12,7 @@ class PaymentEventOutBoxRepositoryImpl(
 ) : PaymentEventOutBoxRepository {
     override fun save(paymentEventOutBox: PaymentEventOutBox): PaymentEventOutBox = eventOutBoxJpaRepository.save(paymentEventOutBox)
 
-    override fun findByPaymentId(paymentId: Long): PaymentEventOutBox = eventOutBoxJpaRepository.findByPaymentId(paymentId)
+    override fun findByPaymentId(paymentId: Long): PaymentEventOutBox? = eventOutBoxJpaRepository.findByPaymentId(paymentId)
 
     override fun findAllFailedEvent(dateTime: LocalDateTime): List<PaymentEventOutBox> =
         eventOutBoxJpaRepository.findAllFailedEvent(dateTime)

--- a/src/main/kotlin/com/hhplus/concert/infrastructure/impl/PaymentEventOutBoxRepositoryImpl.kt
+++ b/src/main/kotlin/com/hhplus/concert/infrastructure/impl/PaymentEventOutBoxRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
 import com.hhplus.concert.business.domain.repository.PaymentEventOutBoxRepository
 import com.hhplus.concert.infrastructure.jpa.EventOutBoxJpaRepository
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 class PaymentEventOutBoxRepositoryImpl(
@@ -12,4 +13,11 @@ class PaymentEventOutBoxRepositoryImpl(
     override fun save(paymentEventOutBox: PaymentEventOutBox): PaymentEventOutBox = eventOutBoxJpaRepository.save(paymentEventOutBox)
 
     override fun findByPaymentId(paymentId: Long): PaymentEventOutBox = eventOutBoxJpaRepository.findByPaymentId(paymentId)
+
+    override fun findAllFailedEvent(dateTime: LocalDateTime): List<PaymentEventOutBox> =
+        eventOutBoxJpaRepository.findAllFailedEvent(dateTime)
+
+    override fun deleteAllPublishedEvent(dateTime: LocalDateTime) {
+        eventOutBoxJpaRepository.deleteAllPublishedEvent(dateTime)
+    }
 }

--- a/src/main/kotlin/com/hhplus/concert/infrastructure/impl/PaymentEventOutBoxRepositoryImpl.kt
+++ b/src/main/kotlin/com/hhplus/concert/infrastructure/impl/PaymentEventOutBoxRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.hhplus.concert.infrastructure.impl
+
+import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
+import com.hhplus.concert.business.domain.repository.PaymentEventOutBoxRepository
+import com.hhplus.concert.infrastructure.jpa.EventOutBoxJpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class PaymentEventOutBoxRepositoryImpl(
+    private val eventOutBoxJpaRepository: EventOutBoxJpaRepository,
+) : PaymentEventOutBoxRepository {
+    override fun save(paymentEventOutBox: PaymentEventOutBox): PaymentEventOutBox = eventOutBoxJpaRepository.save(paymentEventOutBox)
+
+    override fun findByPaymentId(paymentId: Long): PaymentEventOutBox = eventOutBoxJpaRepository.findByPaymentId(paymentId)
+}

--- a/src/main/kotlin/com/hhplus/concert/infrastructure/jpa/EventOutBoxJpaRepository.kt
+++ b/src/main/kotlin/com/hhplus/concert/infrastructure/jpa/EventOutBoxJpaRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query
 import java.time.LocalDateTime
 
 interface EventOutBoxJpaRepository : JpaRepository<PaymentEventOutBox, Long> {
-    fun findByPaymentId(paymentId: Long): PaymentEventOutBox
+    fun findByPaymentId(paymentId: Long): PaymentEventOutBox?
 
     @Query("select peo from PaymentEventOutBox peo where peo.eventStatus = 'INIT' and peo.publishedAt < :dateTime")
     fun findAllFailedEvent(dateTime: LocalDateTime): List<PaymentEventOutBox>

--- a/src/main/kotlin/com/hhplus/concert/infrastructure/jpa/EventOutBoxJpaRepository.kt
+++ b/src/main/kotlin/com/hhplus/concert/infrastructure/jpa/EventOutBoxJpaRepository.kt
@@ -2,7 +2,17 @@ package com.hhplus.concert.infrastructure.jpa
 
 import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
 
 interface EventOutBoxJpaRepository : JpaRepository<PaymentEventOutBox, Long> {
     fun findByPaymentId(paymentId: Long): PaymentEventOutBox
+
+    @Query("select peo from PaymentEventOutBox peo where peo.eventStatus = 'INIT' and peo.publishedAt < :dateTime")
+    fun findAllFailedEvent(dateTime: LocalDateTime): List<PaymentEventOutBox>
+
+    @Modifying
+    @Query("delete from PaymentEventOutBox peo where peo.eventStatus = 'PUBLISHED' and peo.publishedAt < :dateTime")
+    fun deleteAllPublishedEvent(dateTime: LocalDateTime)
 }

--- a/src/main/kotlin/com/hhplus/concert/infrastructure/jpa/EventOutBoxJpaRepository.kt
+++ b/src/main/kotlin/com/hhplus/concert/infrastructure/jpa/EventOutBoxJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.hhplus.concert.infrastructure.jpa
+
+import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EventOutBoxJpaRepository : JpaRepository<PaymentEventOutBox, Long> {
+    fun findByPaymentId(paymentId: Long): PaymentEventOutBox
+}

--- a/src/main/kotlin/com/hhplus/concert/infrastructure/kafka/PaymentEventKafkaProducer.kt
+++ b/src/main/kotlin/com/hhplus/concert/infrastructure/kafka/PaymentEventKafkaProducer.kt
@@ -1,0 +1,19 @@
+package com.hhplus.concert.infrastructure.kafka
+
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentEventKafkaProducer(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+) {
+    /**
+     * Kafka Template 을 통해 Kafka 에게 message 를 전송하는지 확인하는 메서드
+     */
+    fun send(
+        topic: String,
+        message: String,
+    ) {
+        kafkaTemplate.send(topic, message)
+    }
+}

--- a/src/main/kotlin/com/hhplus/concert/infrastructure/kafka/PaymentEventKafkaProducer.kt
+++ b/src/main/kotlin/com/hhplus/concert/infrastructure/kafka/PaymentEventKafkaProducer.kt
@@ -1,7 +1,10 @@
 package com.hhplus.concert.infrastructure.kafka
 
 import com.hhplus.concert.business.domain.manager.payment.event.PaymentEvent
+import com.hhplus.concert.business.domain.manager.payment.event.PaymentEventOutBoxManager
 import com.hhplus.concert.business.domain.manager.payment.event.PaymentEventPublisher
+import com.hhplus.concert.common.type.EventStatus
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
@@ -10,7 +13,10 @@ import org.springframework.stereotype.Component
 @Qualifier("kafka")
 class PaymentEventKafkaProducer(
     private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val paymentEventOutBoxManager: PaymentEventOutBoxManager,
 ) : PaymentEventPublisher {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
     /**
      * Kafka Template 을 통해 Kafka 에게 message 를 전송하는지 확인하는 메서드
      */
@@ -21,7 +27,18 @@ class PaymentEventKafkaProducer(
         kafkaTemplate.send(topic, message)
     }
 
+    /**
+     * 카프카 이벤트를 발행한다.
+     * - 카프카 발행이 성공한다면 (WhenComplete), OutBox의 상태를 PUBLISHED 로 변경한다.
+     */
     override fun publishPaymentEvent(event: PaymentEvent) {
-        kafkaTemplate.send("payment-event", event.paymentId.toString())
+        kafkaTemplate
+            .send("payment-event", event.paymentId.toString())
+            .whenComplete { _, error ->
+                if (error != null) {
+                    logger.info("Kafka payment event published")
+                    paymentEventOutBoxManager.updateEventStatus(event.paymentId, EventStatus.PUBLISHED)
+                }
+            }
     }
 }

--- a/src/main/kotlin/com/hhplus/concert/infrastructure/kafka/PaymentEventKafkaProducer.kt
+++ b/src/main/kotlin/com/hhplus/concert/infrastructure/kafka/PaymentEventKafkaProducer.kt
@@ -1,12 +1,18 @@
 package com.hhplus.concert.infrastructure.kafka
 
+import com.hhplus.concert.business.domain.manager.payment.event.PaymentEvent
+import com.hhplus.concert.business.domain.manager.payment.event.PaymentEventPublisher
+import com.hhplus.concert.business.domain.repository.PaymentEventOutBoxRepository
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
 
 @Component
+@Qualifier("kafka")
 class PaymentEventKafkaProducer(
     private val kafkaTemplate: KafkaTemplate<String, String>,
-) {
+    private val paymentEventOutBoxRepository: PaymentEventOutBoxRepository,
+) : PaymentEventPublisher {
     /**
      * Kafka Template 을 통해 Kafka 에게 message 를 전송하는지 확인하는 메서드
      */
@@ -15,5 +21,9 @@ class PaymentEventKafkaProducer(
         message: String,
     ) {
         kafkaTemplate.send(topic, message)
+    }
+
+    override fun publishPaymentEvent(event: PaymentEvent) {
+        TODO("Not yet implemented")
     }
 }

--- a/src/main/kotlin/com/hhplus/concert/infrastructure/kafka/PaymentEventKafkaProducer.kt
+++ b/src/main/kotlin/com/hhplus/concert/infrastructure/kafka/PaymentEventKafkaProducer.kt
@@ -2,7 +2,6 @@ package com.hhplus.concert.infrastructure.kafka
 
 import com.hhplus.concert.business.domain.manager.payment.event.PaymentEvent
 import com.hhplus.concert.business.domain.manager.payment.event.PaymentEventPublisher
-import com.hhplus.concert.business.domain.repository.PaymentEventOutBoxRepository
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
@@ -11,7 +10,6 @@ import org.springframework.stereotype.Component
 @Qualifier("kafka")
 class PaymentEventKafkaProducer(
     private val kafkaTemplate: KafkaTemplate<String, String>,
-    private val paymentEventOutBoxRepository: PaymentEventOutBoxRepository,
 ) : PaymentEventPublisher {
     /**
      * Kafka Template 을 통해 Kafka 에게 message 를 전송하는지 확인하는 메서드
@@ -24,6 +22,6 @@ class PaymentEventKafkaProducer(
     }
 
     override fun publishPaymentEvent(event: PaymentEvent) {
-        TODO("Not yet implemented")
+        kafkaTemplate.send("payment-event", event.paymentId.toString())
     }
 }

--- a/src/main/kotlin/com/hhplus/concert/infrastructure/publisher/PaymentEventPublisherImpl.kt
+++ b/src/main/kotlin/com/hhplus/concert/infrastructure/publisher/PaymentEventPublisherImpl.kt
@@ -1,11 +1,13 @@
 package com.hhplus.concert.infrastructure.publisher
 
-import com.hhplus.concert.business.domain.manager.payment.PaymentEvent
-import com.hhplus.concert.business.domain.manager.payment.PaymentEventPublisher
+import com.hhplus.concert.business.domain.manager.payment.event.PaymentEvent
+import com.hhplus.concert.business.domain.manager.payment.event.PaymentEventPublisher
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 
 @Component
+@Qualifier("application")
 class PaymentEventPublisherImpl(
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) : PaymentEventPublisher {

--- a/src/main/kotlin/com/hhplus/concert/interfaces/consumer/PaymentEventKafkaConsumer.kt
+++ b/src/main/kotlin/com/hhplus/concert/interfaces/consumer/PaymentEventKafkaConsumer.kt
@@ -1,0 +1,18 @@
+package com.hhplus.concert.interfaces.consumer
+
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentEventKafkaConsumer {
+    var receivedMessage: String? = null
+
+    /**
+     * Kafka 가 이벤트를 잘 Consume 하는 지 테스트 하기 위한 메서드
+     */
+    @KafkaListener(topics = ["test_topic"], groupId = "test-group")
+    fun consume(message: String) {
+        println("Received message: $message")
+        receivedMessage = message
+    }
+}

--- a/src/main/kotlin/com/hhplus/concert/interfaces/consumer/PaymentEventKafkaConsumer.kt
+++ b/src/main/kotlin/com/hhplus/concert/interfaces/consumer/PaymentEventKafkaConsumer.kt
@@ -1,10 +1,15 @@
 package com.hhplus.concert.interfaces.consumer
 
+import com.hhplus.concert.business.application.service.PaymentService
+import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 
 @Component
-class PaymentEventKafkaConsumer {
+class PaymentEventKafkaConsumer(
+    private val paymentService: PaymentService,
+) {
     var receivedMessage: String? = null
 
     /**
@@ -15,4 +20,13 @@ class PaymentEventKafkaConsumer {
         println("Received message: $message")
         receivedMessage = message
     }
+
+    @Async
+    @KafkaListener(topics = ["payment-event"], groupId = "concert")
+    fun handleSendMessageKafkaEvent(paymentId: String) {
+        logger.info("KafkaEvent received")
+        paymentService.sendPaymentEventMessage(paymentId.toLong())
+    }
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
 }

--- a/src/main/kotlin/com/hhplus/concert/interfaces/consumer/PaymentEventKafkaConsumer.kt
+++ b/src/main/kotlin/com/hhplus/concert/interfaces/consumer/PaymentEventKafkaConsumer.kt
@@ -22,7 +22,7 @@ class PaymentEventKafkaConsumer(
     }
 
     @Async
-    @KafkaListener(topics = ["payment-event"], groupId = "concert")
+    @KafkaListener(topics = ["payment-event"], groupId = "payment-group")
     fun handleSendMessageKafkaEvent(paymentId: String) {
         logger.info("KafkaEvent received")
         paymentService.sendPaymentEventMessage(paymentId.toLong())

--- a/src/main/kotlin/com/hhplus/concert/interfaces/event/PaymentEventListener.kt
+++ b/src/main/kotlin/com/hhplus/concert/interfaces/event/PaymentEventListener.kt
@@ -35,11 +35,6 @@ class PaymentEventListener(
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun publishReservationEvent(event: PaymentEvent) {
-        paymentEventOutBoxService.updateEventStatus(
-            paymentId = event.paymentId,
-            eventStatus = EventStatus.PUBLISHED,
-        )
-
         paymentEventOutBoxService.publishPaymentEvent(event)
     }
 

--- a/src/main/kotlin/com/hhplus/concert/interfaces/event/PaymentEventListener.kt
+++ b/src/main/kotlin/com/hhplus/concert/interfaces/event/PaymentEventListener.kt
@@ -40,7 +40,7 @@ class PaymentEventListener(
             eventStatus = EventStatus.PUBLISHED,
         )
 
-        TODO("Kafka Event 발행")
+        paymentEventOutBoxService.publishPaymentEvent(event)
     }
 
     private val logger = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/com/hhplus/concert/interfaces/event/PaymentEventListener.kt
+++ b/src/main/kotlin/com/hhplus/concert/interfaces/event/PaymentEventListener.kt
@@ -1,7 +1,8 @@
 package com.hhplus.concert.interfaces.event
 
-import com.hhplus.concert.business.application.service.PaymentService
-import com.hhplus.concert.business.domain.manager.payment.PaymentEvent
+import com.hhplus.concert.business.application.service.PaymentEventOutBoxService
+import com.hhplus.concert.business.domain.manager.payment.event.PaymentEvent
+import com.hhplus.concert.common.type.EventStatus
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
@@ -10,13 +11,36 @@ import org.springframework.transaction.event.TransactionalEventListener
 
 @Component
 class PaymentEventListener(
-    private val paymentService: PaymentService,
+    private val paymentEventOutBoxService: PaymentEventOutBoxService,
 ) {
+    /**
+     * 커밋 전 (Before commit) 에 Outbox 를 저장한다.
+     * 1. 커밋 전에 outbox 가 저장 되었으므로, 트랜잭션이 실패했어도 outbox 는 Init 상태로 저장이 된다.
+     * 2. 만일 트랜잭션이 실패한 경우의 outbox 는 batch 를 통해 재시도를 하도록 한다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    fun saveEventOutBoxForPaymentCompleted(event: PaymentEvent) {
+        logger.info("EventOutBox 저장 - Payment Id : ${event.paymentId}")
+        paymentEventOutBoxService.saveEventOutBox(
+            domainId = event.paymentId,
+            eventStatus = EventStatus.INIT,
+        )
+    }
+
+    /**
+     * 커밋 이후 (After commit) 에는 다음과 같은 일을 수행한다.
+     * 1. 해당 outbox 의 상태를 변경한다.
+     * 2. kafka event 를 발행한다.
+     */
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun listenMessageEvent(event: PaymentEvent) {
-        logger.info("PaymentEventListener")
-        paymentService.sendPaymentEventMessage(event.paymentId)
+    fun publishReservationEvent(event: PaymentEvent) {
+        paymentEventOutBoxService.updateEventStatus(
+            paymentId = event.paymentId,
+            eventStatus = EventStatus.PUBLISHED,
+        )
+
+        TODO("Kafka Event 발행")
     }
 
     private val logger = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/com/hhplus/concert/interfaces/event/PaymentEventListener.kt
+++ b/src/main/kotlin/com/hhplus/concert/interfaces/event/PaymentEventListener.kt
@@ -15,8 +15,6 @@ class PaymentEventListener(
 ) {
     /**
      * 커밋 전 (Before commit) 에 Outbox 를 저장한다.
-     * 1. 커밋 전에 outbox 가 저장 되었으므로, 트랜잭션이 실패했어도 outbox 는 Init 상태로 저장이 된다.
-     * 2. 만일 트랜잭션이 실패한 경우의 outbox 는 batch 를 통해 재시도를 하도록 한다.
      */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     fun saveEventOutBoxForPaymentCompleted(event: PaymentEvent) {
@@ -29,8 +27,7 @@ class PaymentEventListener(
 
     /**
      * 커밋 이후 (After commit) 에는 다음과 같은 일을 수행한다.
-     * 1. 해당 outbox 의 상태를 변경한다.
-     * 2. kafka event 를 발행한다.
+     * 1. kafka event 를 발행한다.
      */
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/src/main/kotlin/com/hhplus/concert/interfaces/scheduler/PaymentEventScheduler.kt
+++ b/src/main/kotlin/com/hhplus/concert/interfaces/scheduler/PaymentEventScheduler.kt
@@ -1,0 +1,37 @@
+package com.hhplus.concert.interfaces.scheduler
+
+import com.hhplus.concert.business.application.service.PaymentEventOutBoxService
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentEventScheduler(
+    private val paymentEventOutBoxService: PaymentEventOutBoxService,
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    /**
+     * 발행이 실패 이벤트를 다시 재시도한다.
+     * 조건 >
+     * - Init 상태인 이벤트
+     * - publishedAt 이 현재 시간 기준으로 5분 이상 넘어간 이벤트
+     */
+    @Scheduled(fixedRate = 60000)
+    fun retryFailedPaymentEvent() {
+        logger.info("Retry Failed Payment Event Scheduler Executed")
+        paymentEventOutBoxService.retryFailedPaymentEvent()
+    }
+
+    /**
+     * 발행이 완료된 이벤트를 삭제한다.
+     * 조건 >
+     * - PUBLISHED 상태인 이벤트
+     * - publishedAt 이 현재 시간 기준으로 7일 이상 넘어간 이벤트
+     */
+    @Scheduled(fixedRate = 60000)
+    fun deletePublishedPaymentEvent() {
+        logger.info("Delete Publish Payment Event Scheduler Executed")
+        paymentEventOutBoxService.deletePublishedPaymentEvent()
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local
+    active: test
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -17,6 +17,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  kafka:
+    bootstrap-servers: localhost:29092
 
 jwt:
   secret: concert_jwt_secretconcert_jwt_secretconcert_jwt_secretconcert_jwt_secretconcert_jwt_secret

--- a/src/test/kotlin/com/hhplus/concert/application/facade/integration/PaymentEventOutBoxServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/hhplus/concert/application/facade/integration/PaymentEventOutBoxServiceIntegrationTest.kt
@@ -1,0 +1,82 @@
+package com.hhplus.concert.application.facade.integration
+
+import com.hhplus.concert.business.application.service.PaymentEventOutBoxService
+import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
+import com.hhplus.concert.business.domain.repository.PaymentEventOutBoxRepository
+import com.hhplus.concert.common.type.EventStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.concurrent.CompletableFuture
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class PaymentEventOutBoxServiceIntegrationTest {
+    @Autowired
+    private lateinit var paymentEventOutBoxService: PaymentEventOutBoxService
+
+    @Autowired
+    private lateinit var paymentEventOutBoxRepository: PaymentEventOutBoxRepository
+
+    @MockBean
+    private lateinit var kafkaTemplate: KafkaTemplate<String, String>
+
+    @Test
+    fun `5분_이상_지난_INIT_상태의_이벤트를_재시도하고_Kafka에_발행한다`() {
+        // Given
+        val oldEvent = PaymentEventOutBox(paymentId = 1, eventStatus = EventStatus.INIT, publishedAt = LocalDateTime.now().minusMinutes(6))
+        val recentEvent =
+            PaymentEventOutBox(paymentId = 2, eventStatus = EventStatus.INIT, publishedAt = LocalDateTime.now().minusMinutes(4))
+        paymentEventOutBoxRepository.save(oldEvent)
+        paymentEventOutBoxRepository.save(recentEvent)
+
+        val mockSendResultFuture = mock(CompletableFuture::class.java) as CompletableFuture<SendResult<String, String>>
+        `when`(kafkaTemplate.send(anyString(), anyString())).thenReturn(mockSendResultFuture)
+
+        `when`(mockSendResultFuture.whenComplete(any())).thenAnswer {
+            val callback = it.arguments[0] as (SendResult<String, String>?, Throwable?) -> Unit
+            callback.invoke(mock(SendResult::class.java) as SendResult<String, String>, null)
+            mockSendResultFuture
+        }
+
+        // When
+        paymentEventOutBoxService.retryFailedPaymentEvent()
+
+        // Then
+        val updatedOldEvent = paymentEventOutBoxRepository.findByPaymentId(oldEvent.paymentId)
+        val updatedRecentEvent = paymentEventOutBoxRepository.findByPaymentId(recentEvent.paymentId)
+
+        assertEquals("PUBLISHED", updatedOldEvent!!.eventStatus)
+        assertEquals("INIT", updatedRecentEvent!!.eventStatus)
+        verify(kafkaTemplate, times(1)).send("payment-event", "payment1")
+        verify(kafkaTemplate, never()).send("payment-event", "payment2")
+    }
+
+    @Test
+    fun `7일_이상_지난_PUBLISHED_상태의_이벤트를_삭제한다`() {
+        // Given
+        val oldPublishedEvent =
+            PaymentEventOutBox(paymentId = 1, eventStatus = EventStatus.INIT, publishedAt = LocalDateTime.now().minusDays(8))
+        val recentPublishedEvent =
+            PaymentEventOutBox(paymentId = 2, eventStatus = EventStatus.INIT, publishedAt = LocalDateTime.now().minusDays(6))
+        paymentEventOutBoxRepository.save(oldPublishedEvent)
+        paymentEventOutBoxRepository.save(recentPublishedEvent)
+
+        // When
+        paymentEventOutBoxService.deletePublishedPaymentEvent()
+
+        // Then
+        assertThat(paymentEventOutBoxRepository.findByPaymentId(oldPublishedEvent.paymentId)).isNull()
+        assertThat(paymentEventOutBoxRepository.findByPaymentId(recentPublishedEvent.paymentId)!!.paymentId).isEqualTo(2L)
+    }
+}

--- a/src/test/kotlin/com/hhplus/concert/domain/manager/payment/PaymentEventOutBoxManagerTest.kt
+++ b/src/test/kotlin/com/hhplus/concert/domain/manager/payment/PaymentEventOutBoxManagerTest.kt
@@ -1,0 +1,80 @@
+package com.hhplus.concert.domain.manager.payment
+
+import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
+import com.hhplus.concert.business.domain.manager.payment.event.PaymentEventOutBoxManager
+import com.hhplus.concert.business.domain.repository.PaymentEventOutBoxRepository
+import com.hhplus.concert.common.type.EventStatus
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class PaymentEventOutBoxManagerTest {
+    @Mock
+    private lateinit var paymentEventOutBoxRepository: PaymentEventOutBoxRepository
+
+    @InjectMocks
+    private lateinit var paymentEventOutBoxManager: PaymentEventOutBoxManager
+
+    @BeforeEach
+    fun setUp() {
+        paymentEventOutBoxManager = PaymentEventOutBoxManager(paymentEventOutBoxRepository)
+    }
+
+    @Test
+    fun `이벤트 아웃박스 저장 테스트`() {
+        // Given
+        val paymentId = 1L
+        val eventStatus = EventStatus.INIT
+        val expectedOutBox = PaymentEventOutBox(paymentId, eventStatus)
+
+        `when`(
+            paymentEventOutBoxRepository.save(
+                PaymentEventOutBox(paymentId, eventStatus),
+            ),
+        ).thenReturn(expectedOutBox)
+
+        // When
+        val result = paymentEventOutBoxManager.saveEventOutBox(paymentId, eventStatus)
+
+        // Then
+        assert(result.paymentId == paymentId)
+    }
+
+    @Test
+    fun `결제 ID로 이벤트 찾기 테스트`() {
+        // Given
+        val paymentId = 1L
+        val expectedOutBox = PaymentEventOutBox(paymentId, EventStatus.INIT)
+
+        `when`(paymentEventOutBoxRepository.findByPaymentId(paymentId)).thenReturn(expectedOutBox)
+
+        // When
+        val result = paymentEventOutBoxManager.findEventByPaymentId(paymentId)
+
+        // Then
+        assert(result == expectedOutBox)
+    }
+
+    @Test
+    fun `이벤트 상태 업데이트 테스트`() {
+        // Given
+        val paymentId = 1L
+        val newEventStatus = EventStatus.PUBLISHED
+        val existingOutBox = PaymentEventOutBox(paymentId, EventStatus.INIT)
+
+        `when`(paymentEventOutBoxRepository.findByPaymentId(paymentId)).thenReturn(existingOutBox)
+
+        // When
+        paymentEventOutBoxManager.updateEventStatus(paymentId, newEventStatus)
+
+        // Then
+        verify(paymentEventOutBoxRepository).findByPaymentId(paymentId)
+        assert(existingOutBox.eventStatus == newEventStatus)
+    }
+}

--- a/src/test/kotlin/com/hhplus/concert/interfaces/kafka/KafkaConnectionTest.kt
+++ b/src/test/kotlin/com/hhplus/concert/interfaces/kafka/KafkaConnectionTest.kt
@@ -1,0 +1,35 @@
+package com.hhplus.concert.interfaces.kafka
+
+import com.hhplus.concert.infrastructure.kafka.PaymentEventKafkaProducer
+import com.hhplus.concert.interfaces.consumer.PaymentEventKafkaConsumer
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.test.annotation.DirtiesContext
+import java.util.concurrent.TimeUnit
+
+@SpringBootTest
+@EmbeddedKafka(partitions = 1, brokerProperties = ["listeners=PLAINTEXT://localhost:29092"], ports = [29092])
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class KafkaConnectionTest {
+    @Autowired
+    private lateinit var paymentEventKafkaProducer: PaymentEventKafkaProducer
+
+    @Autowired
+    private lateinit var paymentEventKafkaConsumer: PaymentEventKafkaConsumer
+
+    @Test
+    fun `카프카 연결 테스트`() {
+        val topic = "test_topic"
+        val message = "testMessage"
+
+        paymentEventKafkaProducer.send(topic, message)
+
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted {
+            assertThat(paymentEventKafkaConsumer.receivedMessage).isEqualTo(message)
+        }
+    }
+}

--- a/src/test/kotlin/com/hhplus/concert/interfaces/scheduler/PaymentEventSchedulerTest.kt
+++ b/src/test/kotlin/com/hhplus/concert/interfaces/scheduler/PaymentEventSchedulerTest.kt
@@ -1,0 +1,62 @@
+package com.hhplus.concert.interfaces.scheduler
+
+import com.hhplus.concert.business.domain.entity.PaymentEventOutBox
+import com.hhplus.concert.business.domain.repository.PaymentEventOutBoxRepository
+import com.hhplus.concert.common.type.EventStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class PaymentEventSchedulerTest {
+    @Autowired
+    private lateinit var paymentEventScheduler: PaymentEventScheduler
+
+    @Autowired
+    private lateinit var paymentEventOutBoxRepository: PaymentEventOutBoxRepository
+
+    @Test
+    fun `5분_이상_지난_INIT_상태의_이벤트를_재시도한다`() {
+        // Given
+        val oldEvent = PaymentEventOutBox(paymentId = 1, eventStatus = EventStatus.INIT, publishedAt = LocalDateTime.now().minusMinutes(6))
+        val recentEvent =
+            PaymentEventOutBox(paymentId = 2, eventStatus = EventStatus.INIT, publishedAt = LocalDateTime.now().minusMinutes(4))
+        paymentEventOutBoxRepository.save(oldEvent)
+        paymentEventOutBoxRepository.save(recentEvent)
+
+        // When
+        paymentEventScheduler.retryFailedPaymentEvent()
+
+        // Then
+        val updatedOldEvent = paymentEventOutBoxRepository.findByPaymentId(oldEvent.paymentId)
+        val updatedRecentEvent = paymentEventOutBoxRepository.findByPaymentId(recentEvent.paymentId)
+
+        assertEquals("PUBLISHED", updatedOldEvent!!.eventStatus)
+        assertEquals("INIT", updatedRecentEvent!!.eventStatus)
+    }
+
+    @Test
+    fun `7일_이상_지난_PUBLISHED_상태의_이벤트를_삭제한다`() {
+        // Given
+        val oldPublishedEvent =
+            PaymentEventOutBox(paymentId = 1, eventStatus = EventStatus.INIT, publishedAt = LocalDateTime.now().minusDays(8))
+        val recentPublishedEvent =
+            PaymentEventOutBox(paymentId = 2, eventStatus = EventStatus.INIT, publishedAt = LocalDateTime.now().minusDays(6))
+        paymentEventOutBoxRepository.save(oldPublishedEvent)
+        paymentEventOutBoxRepository.save(recentPublishedEvent)
+
+        // When
+        paymentEventScheduler.deletePublishedPaymentEvent()
+
+        // Then
+        assertThat(paymentEventOutBoxRepository.findByPaymentId(oldPublishedEvent.paymentId)).isNull()
+        assertThat(paymentEventOutBoxRepository.findByPaymentId(recentPublishedEvent.paymentId)!!.paymentId).isEqualTo(2L)
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    active: local
+
   datasource:
     url: jdbc:h2:mem:test;NON_KEYWORDS=USER
     driverClassName: org.h2.Driver
@@ -12,7 +15,14 @@ spring:
         hbm2ddl:
           auto: create-drop
         show_sql: true
+  kafka:
+    bootstrap-servers: localhost:29092
 
 jwt:
   secret: concert_jwt_secretconcert_jwt_secretconcert_jwt_secretconcert_jwt_secretconcert_jwt_secret
   expiration-days: 1
+
+slack:
+  checkin:
+    webhook:
+      base_url: "https://hooks.slack.com/services/"


### PR DESCRIPTION
## Kafka 를 어플리케이션과 연동하고, Producer 와 Consumer 테스트를 작성한다.

### 개발내용

- `KafkaConfig` 를 통해 설정정보를 구현한다.
- 테스트용 Producer 와 Consumer 를 통해 정상적으로 동작하는지 확인한다.

### 동작 확인 스크린샷

- Producer 와 Consumer 정상 동작 테스트 완료
![스크린샷 2024-08-15 오후 7 05 18](https://github.com/user-attachments/assets/c11de791-e872-4396-97ee-d01f874596c6)

- Docker 로 떠있는 kafka, zookeeper
<img width="2033" alt="스크린샷 2024-08-15 오후 9 31 33" src="https://github.com/user-attachments/assets/c9421a7e-c034-4cd2-8f62-983148a58c74">

